### PR TITLE
Replacing gist.user.login by gist.owner.login (following GitHub API change)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -203,7 +203,7 @@ var getInstantStarredGists = function(gistme, callback) {
 };
 
 var createInitialComment = function(gistme, gist) {
-    initial_comment = "Created by Instant Aria Templates, viewable on http://instant.ariatemplates.com/" + gist.user.login + "/" + gist.id;
+    initial_comment = "Created by Instant Aria Templates, viewable on http://instant.ariatemplates.com/" + gist.owner.login + "/" + gist.id;
     gistme.comment_create(gist.id, initial_comment, function(error, comment) {
       if (error) {
         console.error("Error while creating the initial comment for gist#"+gist.id, JSON.stringify(error));
@@ -327,7 +327,7 @@ app.post("/new", userMustBeLoggedIn, getGistme, function(req, res) {
       createInitialComment(gistme, gist);
     }, 1000);
 
-    res.redirect("/" + gist.user.login + "/" + gist.id);
+    res.redirect("/" + gist.owner.login + "/" + gist.id);
   });
 });
 
@@ -547,7 +547,7 @@ app['delete']("/:username/:instant_id", userMustBeLoggedIn, getGistme, function(
       loggedUserLogin = req.user.login;
 
   gistme.fetch(instant_id, function(error, gist) {
-    if (gist.user.login !== username) {
+    if (gist.owner.login !== username) {
       return res.json({
         "error": {
           "message": "Whoops... Seems you are trying to do o_O stuff! <strong>You should not!</strong>"
@@ -555,7 +555,7 @@ app['delete']("/:username/:instant_id", userMustBeLoggedIn, getGistme, function(
       });
     }
 
-    if (gist.user.login !== loggedUserLogin) {
+    if (gist.owner.login !== loggedUserLogin) {
       return res.json({
         "error":  {
           "message": "The instant #" + instant_id + " is not one of yours. You can't delete it !"

--- a/server/views/instant.jade
+++ b/server/views/instant.jade
@@ -6,23 +6,23 @@ block header_scripts
 
 block header
   if everyauth.loggedIn
-    if gist.user.login == user.login
-      .action(data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.edit.save(this)")
+    if gist.owner.login == user.login
+      .action(data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.edit.save(this)")
         i.icon-save
         span Save
-      .action(data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.delete(this)")
+      .action(data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.delete(this)")
         i.icon-trash
         span Delete
-    if gist.user.login !== user.login
-      //- a.action(href="/"+gist.user.login+"/"+gist.id+"/fork")
+    if gist.owner.login !== user.login
+      //- a.action(href="/"+gist.owner.login+"/"+gist.id+"/fork")
       //-   i.icon-code-fork
       //-   span Fork
       if (is_starred(gist.id))
-        .action(data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.unstar(this)")
+        .action(data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.unstar(this)")
           i.icon-star
           span Unstar
       else
-        .action(data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.star(this)")
+        .action(data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.star(this)")
           i.icon-star-empty
           span Star
   //- .action.menu
@@ -61,14 +61,14 @@ prepend footer_right
 
 block footer
   span instant by
-  span: a(href="/" + gist.user.login)= gist.user.login
+  span: a(href="/" + gist.owner.login)= gist.owner.login
   &bull;
   if gist.forks.length > 0
     span #{gist.forks.length} forks
   else
     span no forks
   &bull;
-  span: a(href="https://gist.github.com/#{gist.user.login}/#{gist.id}#comments", target="_blank") #{gist.comments ? 1 : gist.comments} comments
+  span: a(href="https://gist.github.com/#{gist.owner.login}/#{gist.id}#comments", target="_blank") #{gist.comments ? 1 : gist.comments} comments
   if gist.history.length > 0
     &bull;
     span #{gist.history.length} revisions

--- a/server/views/list.jade
+++ b/server/views/list.jade
@@ -16,7 +16,7 @@ mixin list(gists)
         tr
           td.date(title=date(gist.created_at,date_patterns.full))= date(gist.created_at,"MMM DD")
           td
-            div.name: a(href="/#{gist.user.login}/#{gist.id}")= gist.instant_name
+            div.name: a(href="/#{gist.owner.login}/#{gist.id}")= gist.instant_name
             .description !{linkify(gist.instant_description)}
           td.comments(title="Number of comments")
             if (gist.comments > 1)
@@ -32,23 +32,23 @@ mixin list(gists)
             td.starred
               if user_info
                 if (is_starred(gist.id))
-                  span(title="Remove from your favorites", data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.unstar(this)")
+                  span(title="Remove from your favorites", data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.unstar(this)")
                     i.icon-star
                 else
-                  span(title="Add to your favorites", data-id=gist.id, data-user-login=gist.user.login, onclick="window.instant.star(this)")
+                  span(title="Add to your favorites", data-id=gist.id, data-user-login=gist.owner.login, onclick="window.instant.star(this)")
                     i.icon-star-empty
               else
-                if gist.user.login !== user.login
-                  a.icon-star(href="/" + gist.user.login + "/" + gist.id + "/unstar", title="Remove from your favorites")
+                if gist.owner.login !== user.login
+                  a.icon-star(href="/" + gist.owner.login + "/" + gist.id + "/unstar", title="Remove from your favorites")
 
                 else
-                  i.icon-trash(title="Delete this instant forever!", data-id=gist.id, data-user-login=gist.user.login, onclick="window.iat.delete(this)")
+                  i.icon-trash(title="Delete this instant forever!", data-id=gist.id, data-user-login=gist.owner.login, onclick="window.iat.delete(this)")
 
-          if everyauth.loggedIn && gist.user.login === user.login
+          if everyauth.loggedIn && gist.owner.login === user.login
             td.author You
           else
             td.author
-              a(href="/"+gist.user.login)= gist.user.login
+              a(href="/"+gist.owner.login)= gist.owner.login
 
 block content
   if user_info


### PR DESCRIPTION
This commit replaces `gist.user.login` by `gist.owner.login` in the code, following a GitHub API change.
