### PR TITLE
Allowing to change the version of Aria Templates

### DIFF
--- a/public/scripts/atVersion.js
+++ b/public/scripts/atVersion.js
@@ -1,0 +1,36 @@
+(function (instant) {
+    var $ = instant.$;
+
+    var formatVersion = function (version) {
+        return version.replace(/^(\d)(\d)(\d{1,2})$/, "$1.$2.$3");
+    };
+
+    instant.atVersion = {
+        versions : function (info) {
+            var list = info.list;
+            if (!list) {
+                return;
+            }
+            var elt = $("atversion");
+            var currentVersion = elt.firstChild.value;
+            for (var i = 0, l = list.length; i < l; i++) {
+                var version = list[i];
+                if (version != currentVersion) {
+                    var option = document.createElement("option");
+                    elt.appendChild(option);
+                    option.value = version;
+                    option.appendChild(document.createTextNode(formatVersion(version)));
+                }
+            }
+        },
+        change : function () {
+            var elt = $("atversion");
+            var href = window.location.href + "";
+            href = href.replace(/atversion=[^&]*/, "");
+            href = href.replace(/\?$/, "");
+            href += href.indexOf("?") > -1 ? "&" : "?";
+            href += "atversion=" + encodeURIComponent(elt.value);
+            window.location = href;
+        }
+    };
+})(window.instant);

--- a/server/server.js
+++ b/server/server.js
@@ -211,6 +211,17 @@ var createInitialComment = function(gistme, gist) {
     });
 };
 
+var getAtVersion = function(req) {
+    var atversion = req.query.atversion;
+    // minimal validation:
+    if (!atversion || !/^[-\.0-9a-zA-Z]+$/.test(atversion)) {
+        atversion = "latest";
+    }
+    return {
+        display: atversion.replace(/^(\d)(\d)(\d{1,2})$/, "$1.$2.$3"),
+        value: atversion.replace(/^(\d)\.(\d)\.(\d{1,2})$/, "$1$2$3")
+    };
+};
 
 /* EXPRESS ROUTES */
 var file_404 = function(req, res) {
@@ -387,7 +398,8 @@ app.get("/anonymous/:instant_id", getGistme, function(req, res, next) {
     }
     res.render("anonymous_instant", {
       'admin': false,
-      'gist': gist
+      'gist': gist,
+      'atversion': getAtVersion(req)
     });
   });
 });
@@ -425,7 +437,8 @@ app.get("/anonymous/:instant_id/:admin_hash", getGistme, function(req, res, next
     res.render("anonymous_instant", {
       'admin': true,
       'gist': gist,
-      'new_instant': new_anonymous
+      'new_instant': new_anonymous,
+      'atversion': getAtVersion(req)
     });
   });
 });
@@ -477,7 +490,8 @@ app.get("/:username/:instant_id", getGistme, function(req, res, next) {
       return next(new Error());
     }
     res.render("instant", {
-      'gist': gist
+      'gist': gist,
+      'atversion': getAtVersion(req)
     });
   });
 });

--- a/server/views/anonymous_instant.jade
+++ b/server/views/anonymous_instant.jade
@@ -1,8 +1,7 @@
 extends layout
 
 block header_scripts
-  script(type="text/javascript", src='/aria/ariatemplates-1.4.4.js')
-  script(type="text/javascript", src='/aria/css/atskin-1.4.4.js')
+  script(type="text/javascript", src='http://cdn.ariatemplates.com/at'+atversion.value+'.js?skin')
 
 block header
   if (locals.admin)
@@ -47,6 +46,11 @@ block content
 
   #preview-wrapper.preview
     #preview.preview-wrapper
+
+append footer_left
+  span Version:&nbsp;
+    select#atversion(onchange="instant.atVersion.change()")
+      option(value=atversion.value) #{atversion.display}
 
 prepend footer_right
   span.link.kdb-help(title="Show keyboard shorcuts"): i.icon-keyboard(onclick="window.instant.show_keyboard_help()")
@@ -109,5 +113,6 @@ block scripts
         }
       }
     });
-
+  script(type="text/javascript", src="/scripts/atVersion.js")
+  script(type="text/javascript", src="http://cdn.ariatemplates.com/versions?callback=instant.atVersion.versions")
 

--- a/server/views/instant.jade
+++ b/server/views/instant.jade
@@ -1,8 +1,7 @@
 extends layout
 
 block header_scripts
-  script(type="text/javascript", src='/aria/ariatemplates-1.4.4.js')
-  script(type="text/javascript", src='/aria/css/atskin-1.4.4.js')
+  script(type="text/javascript", src='http://cdn.ariatemplates.com/at'+atversion.value+'.js?skin')
 
 block header
   if everyauth.loggedIn
@@ -56,6 +55,11 @@ block content
   #preview-wrapper.preview
     #preview.preview-wrapper
 
+append footer_left
+  span Version:&nbsp;
+    select#atversion(onchange="instant.atVersion.change()")
+      option(value=atversion.value) #{atversion.display}
+
 prepend footer_right
   span.link.kdb-help(title="Show keyboard shorcuts"): i.icon-keyboard(onclick="window.instant.show_keyboard_help()")
 
@@ -101,5 +105,6 @@ block scripts
         }
       }
     });
-
+  script(type="text/javascript", src="/scripts/atVersion.js")
+  script(type="text/javascript", src="http://cdn.ariatemplates.com/versions?callback=instant.atVersion.versions")
 


### PR DESCRIPTION
With this PR, the Aria Templates CDN is used instead of the local version of Aria Templates. The version number can be passed in the url and an html select displays the list of available versions.

Displaying the full list of versions relies on [this change on cdn.ariatemplates.com](https://github.com/ariatemplates/cdn.ariatemplates.com/commit/7306c43fcfeea32995ad277e7323642328d7b0f3) which is now deployed in production (cf [here](http://cdn.ariatemplates.com/versions)).
